### PR TITLE
Only allow openai models we have pricing data for

### DIFF
--- a/.changeset/twelve-apples-nail.md
+++ b/.changeset/twelve-apples-nail.md
@@ -1,0 +1,5 @@
+---
+"safegen": minor
+---
+
+Only allow openai models we have pricing data for

--- a/packages/safegen/break-check.config.json
+++ b/packages/safegen/break-check.config.json
@@ -1,6 +1,6 @@
 {
-	"tagPattern": "@beaugmented/agency",
+	"tagPattern": "safegen",
 	"testPattern": "__tests__/public/**/*.test.{ts,tsx}",
-	"testCommand": "bun run build && bun run test:once:public",
-	"certifyCommand": "echo 'no certify command'"
+	"testCommand": "bun run test:once:public",
+	"certifyCommand": "grep -q -F '\"safegen\": minor' ../../.changeset/*.md"
 }

--- a/packages/safegen/package.json
+++ b/packages/safegen/package.json
@@ -34,8 +34,9 @@
 		"lint": "bun run lint:biome && bun run lint:eslint && bun run lint:types",
 		"test": "vitest",
 		"test:once": "vitest run",
+		"test:once:public": "vitest run public",
 		"test:coverage": "echo no test coverage yet",
-		"test:semver": "bun run build && bun run test:once"
+		"test:semver": "break-check --verbose"
 	},
 	"peerDependencies": {
 		"openai": ">=4.0.0"

--- a/packages/safegen/src/openai/open-ai-safegen-cached.ts
+++ b/packages/safegen/src/openai/open-ai-safegen-cached.ts
@@ -1,15 +1,15 @@
-import type { ChatModel } from "openai/resources/index.mjs"
 import type { Squirreled, SquirrelMode } from "varmint"
 import { Squirrel } from "varmint"
 
 import type { GenerateFromSchema } from "../safegen"
 import { createSafeDataGenerator } from "../safegen"
 import { buildOpenAiRequestParams } from "./build-open-ai-request-params"
+import type { OPEN_AI_PRICING_FACTS } from "./pricing-facts"
 import type { GetUnknownJsonFromOpenAi } from "./set-up-open-ai-generator"
 import { setUpOpenAiJsonGenerator } from "./set-up-open-ai-generator"
 
 export type OpenAiSafeGenOptions = {
-	model: ChatModel
+	model: keyof typeof OPEN_AI_PRICING_FACTS
 	usdBudget: number
 	usdMinimum: number
 	apiKey: string

--- a/packages/safegen/src/openai/open-ai-safegen.ts
+++ b/packages/safegen/src/openai/open-ai-safegen.ts
@@ -1,11 +1,13 @@
-import type { ChatModel } from "openai/resources/index"
-
 import { createSafeDataGenerator } from "../safegen"
 import { buildOpenAiRequestParams } from "./build-open-ai-request-params"
+import type { OPEN_AI_PRICING_FACTS } from "./pricing-facts"
 import { setUpOpenAiJsonGenerator } from "./set-up-open-ai-generator"
 
 let getUnknownJsonFromOpenAi: ReturnType<typeof setUpOpenAiJsonGenerator>
-export const openaiSafeGen = (model: ChatModel, apiKey: string) =>
+export const openaiSafeGen = (
+	model: keyof typeof OPEN_AI_PRICING_FACTS,
+	apiKey: string,
+) =>
 	createSafeDataGenerator((...params) => {
 		if (!getUnknownJsonFromOpenAi) {
 			getUnknownJsonFromOpenAi = setUpOpenAiJsonGenerator(apiKey)


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Updated the `model` type in `OpenAiSafeGenOptions` and `openaiSafeGen` to `keyof typeof OPEN_AI_PRICING_FACTS`, ensuring only models with available pricing data are used.
- Removed the import of `ChatModel` as it is no longer needed.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>open-ai-safegen-cached.ts</strong><dd><code>Restrict model type to available pricing data keys</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/safegen/src/openai/open-ai-safegen-cached.ts

<li>Changed the type of <code>model</code> to <code>keyof typeof OPEN_AI_PRICING_FACTS</code>.<br> <li> Removed import of <code>ChatModel</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/beaugmented/agency/pull/367/files#diff-2547d06291c7f524b61650316891280040f6da1294b79673cbfa546e5d18e135">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>open-ai-safegen.ts</strong><dd><code>Update model type to match pricing data keys</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/safegen/src/openai/open-ai-safegen.ts

<li>Changed the type of <code>model</code> to <code>keyof typeof OPEN_AI_PRICING_FACTS</code>.<br> <li> Removed import of <code>ChatModel</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/beaugmented/agency/pull/367/files#diff-b9c0387e8c050c9935cbca1eb18d7ed72470621b2d0437ded729ca5b9cba2598">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information