### PR TITLE
safegen no node version in engines

### DIFF
--- a/.changeset/nasty-bananas-wait.md
+++ b/.changeset/nasty-bananas-wait.md
@@ -1,0 +1,5 @@
+---
+"safegen": patch
+---
+
+🐛 Remove node version stipulation from safegen's engines field.

--- a/packages/safegen/package.json
+++ b/packages/safegen/package.json
@@ -7,11 +7,6 @@
 		"access": "public"
 	},
 	"packageManager": "pnpm@9.12.3",
-	"engines": {
-		"bun": "1.1.4",
-		"node": "22.11.0",
-		"pnpm": "9.12.3"
-	},
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
 	"module": "dist/index.js",


### PR DESCRIPTION
### **User description**
- **🐛 don't require node 22**
- **🦋**


___

### **PR Type**
enhancement, other


___

### **Description**
- Removed the node version requirement from the `engines` field in `package.json` for the `safegen` package.
- Added a changeset file to document the removal of the node version stipulation.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>nasty-bananas-wait.md</strong><dd><code>Add changeset for safegen node version update</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/nasty-bananas-wait.md

<li>Added a changeset file for safegen.<br> <li> Documented the removal of node version stipulation.<br>


</details>


  </td>
  <td><a href="https://github.com/beaugmented/agency/pull/382/files#diff-7d7eb9dfed4a40a18aee6b3bcbf099d0ba102990c80d9b9731cb465d8b5942d3">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Remove node version requirement from engines field</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/safegen/package.json

<li>Removed the node version requirement from the engines field.<br> <li> Simplified the engines configuration in package.json.<br>


</details>


  </td>
  <td><a href="https://github.com/beaugmented/agency/pull/382/files#diff-4b3270f5435fa2cae5340932425d0760e6a8e8a895dc84c026e34a95179440c7">+0/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information