### PR TITLE
raw usage

### DIFF
--- a/.changeset/soft-crews-kneel.md
+++ b/.changeset/soft-crews-kneel.md
@@ -1,0 +1,5 @@
+---
+"safegen": patch
+---
+
+✨ `OpenAiSafeGenerator` and `AnthropicSafeGenerator` now include usage data in the type of their respective API clients stored as the property `lastUsage`.

--- a/packages/safegen/src/anthropic/anthropic-safe-generator.ts
+++ b/packages/safegen/src/anthropic/anthropic-safe-generator.ts
@@ -28,6 +28,7 @@ export class AnthropicSafeGenerator implements SafeGenerator {
 	public getUnknownJsonFromAnthropicSquirreled: Squirreled<GetUnknownJsonFromAnthropic>
 	public squirrel: Squirrel
 	public client?: Anthropic
+	public lastUsage?: Anthropic.Messages.Usage
 
 	public constructor({
 		model,
@@ -66,13 +67,15 @@ export class AnthropicSafeGenerator implements SafeGenerator {
 			const anthropicParams = buildAnthropicRequestParams(model, ...params)
 			const instruction = params[0]
 			const previouslyFailedResponses = params[3]
-			const response = await this.getUnknownJsonFromAnthropicSquirreled
-				.for(
-					`${instruction.replace(/[^a-zA-Z0-9-_. ]/g, `_`)}-${previouslyFailedResponses.length}`,
-				)
-				.get(anthropicParams)
-			this.usdBudget -= response.usdPrice
-			return response.data
+			const { data, usage, usdPrice } =
+				await this.getUnknownJsonFromAnthropicSquirreled
+					.for(
+						`${instruction.replace(/[^a-zA-Z0-9-_. ]/g, `_`)}-${previouslyFailedResponses.length}`,
+					)
+					.get(anthropicParams)
+			this.lastUsage = usage
+			this.usdBudget -= usdPrice
+			return data
 		})
 	}
 

--- a/packages/safegen/src/anthropic/set-up-anthropic-json-generator.ts
+++ b/packages/safegen/src/anthropic/set-up-anthropic-json-generator.ts
@@ -12,7 +12,11 @@ import {
 export type GetUnknownJsonFromAnthropic = (
 	body: AnthropicResources.MessageCreateParamsNonStreaming,
 	options?: AnthropicCore.RequestOptions,
-) => Promise<{ data: Json.Object; usdPrice: number }>
+) => Promise<{
+	data: Json.Object
+	usage: Anthropic.Messages.Usage
+	usdPrice: number
+}>
 
 export function setUpAnthropicJsonGenerator(
 	client?: Anthropic,
@@ -62,6 +66,6 @@ export function setUpAnthropicJsonGenerator(
 		} catch (error) {
 			data = {}
 		}
-		return { data, usdPrice }
+		return { data, usage, usdPrice }
 	}
 }

--- a/packages/safegen/src/openai/openai-safe-generator.ts
+++ b/packages/safegen/src/openai/openai-safe-generator.ts
@@ -28,6 +28,7 @@ export class OpenAiSafeGenerator implements SafeGenerator {
 	public getUnknownJsonFromOpenAiSquirreled: Squirreled<GetUnknownJsonFromOpenAi>
 	public squirrel: Squirrel
 	public client?: OpenAI
+	public lastUsage?: OpenAI.Completions.CompletionUsage
 
 	public constructor({
 		model,
@@ -66,13 +67,15 @@ export class OpenAiSafeGenerator implements SafeGenerator {
 			const openAiParams = buildOpenAiRequestParams(model, ...params)
 			const instruction = params[0]
 			const previouslyFailedResponses = params[3]
-			const response = await this.getUnknownJsonFromOpenAiSquirreled
-				.for(
-					`${instruction.replace(/[^a-zA-Z0-9-_. ]/g, `_`)}-${previouslyFailedResponses.length}`,
-				)
-				.get(openAiParams)
-			this.usdBudget -= response.usdPrice
-			return response.data
+			const { data, usage, usdPrice } =
+				await this.getUnknownJsonFromOpenAiSquirreled
+					.for(
+						`${instruction.replace(/[^a-zA-Z0-9-_. ]/g, `_`)}-${previouslyFailedResponses.length}`,
+					)
+					.get(openAiParams)
+			this.lastUsage = usage
+			this.usdBudget -= usdPrice
+			return data
 		})
 	}
 

--- a/packages/safegen/src/openai/set-up-openai-json-generator.ts
+++ b/packages/safegen/src/openai/set-up-openai-json-generator.ts
@@ -8,7 +8,11 @@ import { OPEN_AI_PRICING_FACTS } from "./openai-pricing-facts"
 export type GetUnknownJsonFromOpenAi = (
 	body: OpenAIResources.ChatCompletionCreateParamsNonStreaming,
 	options?: OpenAICore.RequestOptions,
-) => Promise<{ data: Json.Object; usdPrice: number }>
+) => Promise<{
+	data: Json.Object
+	usage: OpenAI.Completions.CompletionUsage
+	usdPrice: number
+}>
 
 export function setUpOpenAiJsonGenerator(
 	client?: OpenAI,
@@ -41,7 +45,7 @@ export function setUpOpenAiJsonGenerator(
 					OPEN_AI_PRICING_FACTS[body.model].promptPricePerTokenCached +
 				outputTokens * OPEN_AI_PRICING_FACTS[body.model].completionPricePerToken
 			const data = JSON.parse(content)
-			return { data, usdPrice }
+			return { data, usage, usdPrice }
 		}
 		if (!content && !usage) {
 			throw new Error(`No content or usage found in completion`)


### PR DESCRIPTION
### **User description**
- **✨ capture usage data**
- **🦋**


___

### **PR Type**
Enhancement


___

### **Description**
- Added `lastUsage` property to both `OpenAiSafeGenerator` and `AnthropicSafeGenerator` to store usage data from their respective API responses.
- Updated methods in both generators to extract and assign `usage` and `usdPrice` from API responses.
- Adjusted budget calculations in both generators to use the extracted `usdPrice`.
- Updated return types of `GetUnknownJsonFromAnthropic` and `GetUnknownJsonFromOpenAi` to include `usage`.
- Documented these changes in a changeset file.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>anthropic-safe-generator.ts</strong><dd><code>Add usage data handling to AnthropicSafeGenerator</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/safegen/src/anthropic/anthropic-safe-generator.ts

<li>Added <code>lastUsage</code> property to store usage data from Anthropic API <br>responses.<br> <li> Updated the method to extract and assign <code>usage</code> and <code>usdPrice</code> from API <br>responses.<br> <li> Adjusted budget calculation to use the extracted <code>usdPrice</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/beaugmented/agency/pull/494/files#diff-1f9656d310763b0b8f257bb05c8b6352e0ba1127c4a4d7b39d723ac8cfe93646">+10/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>set-up-anthropic-json-generator.ts</strong><dd><code>Include usage data in Anthropic JSON generator</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/safegen/src/anthropic/set-up-anthropic-json-generator.ts

<li>Updated return type of <code>GetUnknownJsonFromAnthropic</code> to include <code>usage</code>.<br> <li> Modified the function to return <code>usage</code> along with <code>data</code> and <code>usdPrice</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/beaugmented/agency/pull/494/files#diff-426d77a9f400c51fbd6254fdc24a15ec9ac0fe08689b5e39abc185c0fcb6500f">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>openai-safe-generator.ts</strong><dd><code>Add usage data handling to OpenAiSafeGenerator</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/safegen/src/openai/openai-safe-generator.ts

<li>Added <code>lastUsage</code> property to store usage data from OpenAI API <br>responses.<br> <li> Updated the method to extract and assign <code>usage</code> and <code>usdPrice</code> from API <br>responses.<br> <li> Adjusted budget calculation to use the extracted <code>usdPrice</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/beaugmented/agency/pull/494/files#diff-f711a4f9ead087fac849ff482d74694956de967dbd6186152e878c0668583b33">+10/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>set-up-openai-json-generator.ts</strong><dd><code>Include usage data in OpenAI JSON generator</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/safegen/src/openai/set-up-openai-json-generator.ts

<li>Updated return type of <code>GetUnknownJsonFromOpenAi</code> to include <code>usage</code>.<br> <li> Modified the function to return <code>usage</code> along with <code>data</code> and <code>usdPrice</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/beaugmented/agency/pull/494/files#diff-8fdc24ef88e0ece209dbe349925b90513e4c17b24c46493c713954c3865ad6d1">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>soft-crews-kneel.md</strong><dd><code>Document usage data addition in generators</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/soft-crews-kneel.md

<li>Documented the addition of <code>lastUsage</code> property in <code>OpenAiSafeGenerator</code> <br>and <code>AnthropicSafeGenerator</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/beaugmented/agency/pull/494/files#diff-4faa01fd6e3d1b9607c0e9cf7293f6f0548419db98f5a83439507dfecf766ac2">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information